### PR TITLE
fix: Helm S3 args are empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docs:
 
 .PHONY: run
 run:
-	go run $(GOBASE)/cmd/helm-s3-publisher argo /Users/carlosjunior/projects/helm-charts --git-ls-tree --exclude-paths ".git, .github" --log-level trace --report json --dry-run --output text
+	go run $(GOBASE)/cmd/helm-s3-publisher argo /Users/carlosjunior/projects/helm-charts --git-ls-tree --exclude-paths ".git, .github" --log-level trace --report json --dry-run --output text --s3-force --s3-acl "bucket_policy"
 
 
 .PHONY: build

--- a/internal/helpers/args.go
+++ b/internal/helpers/args.go
@@ -6,6 +6,17 @@ func MergeArgs(newArgs []string, args ...string) []string {
 
 	listArgs = append(listArgs, newArgs...)
 	listArgs = append(listArgs, args...)
+	listArgs = DeleteEmpty(listArgs)
 
 	return listArgs
+}
+
+func DeleteEmpty(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
 }

--- a/internal/publish/publisher.go
+++ b/internal/publish/publisher.go
@@ -65,7 +65,6 @@ func (c *Commands) chartPakacge(chartPath string) {
 		chartOutput = viper.GetString("output.path")
 		chartRepo   = viper.GetString("chart.repo")
 		s3Force     = viper.GetBool("helm.s3.force")
-		dryRun      = viper.GetBool("command.dry-run")
 		separator1  = strings.Repeat("=", 80)
 		separator2  = strings.Repeat("-", 80)
 		argForce    = ""
@@ -111,13 +110,9 @@ func (c *Commands) chartPakacge(chartPath string) {
 
 	log.Tracef("%#v, Force? %s", reportChart, argForce)
 
-	if !dryRun {
-		if err := plugins.S3Publisher(m, chartPath, chartRepo, chartOutput, argForce); err != nil {
-			reportChart.Published = false
-			log.Fatalln(err)
-		}
-	} else {
-		log.Warnln("Dry run mode has been activated no publishing process will be executed!")
+	if err := plugins.S3Publisher(m, chartPath, chartRepo, chartOutput, argForce); err != nil {
+		reportChart.Published = false
+		log.Fatalln(err)
 	}
 
 	reportPublish = append(reportPublish, reportChart)


### PR DESCRIPTION
```shell
ERRO[2024-10-04T14:38:52Z] S3Publisher :: Unable to publish version 1.0.1 of package generic check if the specified repository helm-charts-dev exists and has permission to publish. 
FATA[2024-10-04T14:38:52Z] S3Publisher - Err: exit status 1 :Out: []    
Error: plugin "s3-publisher" exited with error
Error: Process completed with exit code 1.
```